### PR TITLE
fix Elba Changes 2025-09

### DIFF
--- a/src/tasks/MeinElba.ts
+++ b/src/tasks/MeinElba.ts
@@ -228,7 +228,7 @@ export default class extends TaskBaseCheerio {
 
   override async *rawTransactionsForAccount(accountDetails: AccountDetails) {
     const token = (accountDetails.entryReferenceFrom || "").split("@");
-    await this.apiGET("/bankingzv-umsatzuebersicht/umsatzuebersicht-ui/rest/kontoumsaetze/" + accountDetails.iban);
+    await this.apiGET("/bankingzv-umsatzuebersicht/umsatzuebersicht-ui/rest/kontoumsaetze/" + accountDetails.iban, {});
     let umsaetze = this.json.list;
     const tokenId = parseInt(token[0], 10);
     if (tokenId) umsaetze = umsaetze.filter((t) => t.id > tokenId);

--- a/src/tasks/MeinElba.ts
+++ b/src/tasks/MeinElba.ts
@@ -228,12 +228,7 @@ export default class extends TaskBaseCheerio {
 
   override async *rawTransactionsForAccount(accountDetails: AccountDetails) {
     const token = (accountDetails.entryReferenceFrom || "").split("@");
-    await this.apiPOST("/bankingzv-umsatz/umsatz-ui/rest/kontoumsaetze", {
-      predicate: {
-        ibans: [accountDetails.iban],
-        buchungVon: token[1],
-      },
-    });
+    await this.apiGET("/bankingzv-umsatzuebersicht/umsatzuebersicht-ui/rest/kontoumsaetze/" + accountDetails.iban);
     let umsaetze = this.json.list;
     const tokenId = parseInt(token[0], 10);
     if (tokenId) umsaetze = umsaetze.filter((t) => t.id > tokenId);

--- a/src/tasks/MeinElba.ts
+++ b/src/tasks/MeinElba.ts
@@ -231,8 +231,9 @@ export default class extends TaskBaseCheerio {
     await this.apiGET("/bankingzv-umsatzuebersicht/umsatzuebersicht-ui/rest/kontoumsaetze/" + accountDetails.iban, {});
     let umsaetze = this.json.list;
     const tokenId = parseInt(token[0], 10);
-    if (tokenId) umsaetze = umsaetze.filter((t) => t.id > tokenId);
-
+	const fromDate = new Date(token[1]);
+    if (tokenId) umsaetze = umsaetze.filter((t) => t.id > tokenId && new Date(t.buchungstag) >= fromDate);
+	  
     for (const item of umsaetze) yield item;
   }
 

--- a/src/tasks/MeinElba.ts
+++ b/src/tasks/MeinElba.ts
@@ -237,7 +237,9 @@ export default class extends TaskBaseCheerio {
   }
 
   override mapRawTransaction(item: any): Transaction {
-    const { amount } = item.betrag;
+    const amount = typeof item.betrag.amount === 'number'
+	    ? item.betrag.amount
+	    : item.betrag.amount?.parsedValue;
     const reference = [
       item.zahlungsreferenz,
       item.verwendungszweckZeile1,

--- a/src/tasks/MeinElba.ts
+++ b/src/tasks/MeinElba.ts
@@ -9,7 +9,7 @@ import TaskBaseCheerio from "../TaskBaseCheerio";
 
 function toAmount({ amount, currency }) {
   return {
-    amount: String(amount),
+    amount: typeof amount === 'number' ? String(amount) : amount?.source
     currency,
   };
 }


### PR DESCRIPTION
Seit 16.9.2025 funktioniert der Import der Banktransaktionen nicht mehr, nur der Kontostand wird noch importiert. Eine Netzwerkanalyse beim Einloggen ins Ebanking hat gezeigt, dass für die Kontobuchungen offenbar andere API-Anfragen als bisher verwendet werden und außerdem die IDs der Buchungen zurück gesetzt wurden:
https://github.com/mjavurek/foodsoft-scraping/tree/caa223edc053b577d7fd22bba87a62629c82dccb/python/import-elba

Ich habe versucht, alles an die neue Situation anzupassen, konnte den ts-Code aber nicht testen.
Nachdem ich in der Datenbanktabelle bank_accounts den Wert von import_continuation_point auf die ID und das Datum der letzten manuellen Import Transaktion aus der Tabelle bank_transactions (in unserem Fall von
`13787462040@2025-09-16T00:00:00` auf 
`98595636@2025-10-07T00:00:00`) gesetzt habe, hat der Import wieder funktioniert. Obwohl das ELBA im Webbrowser (mittlerweile?) eine andere API Kommunikation verwendet, scheint die bisherige API Abfrage doch noch zu funktionieren, sofern der ID Sprung nach unten einmalig berücksichtigt wird. Es ist also (noch) nicht nötig, den Bankpoxy Programmcode zu ändern.

Es muss also in den Datenbanken der betroffenen Foodcoops in der Tabelle `bank_accounts` der Wert für `import_continuation_point` auf `0@YYYY-MM-DD...` gesetzt werden, wobei `YYYY-MM-DD...` das Datum ist, das schon im dort steht, falls seit der Umstellung keine manuellen Importe durchgeführt wurden, oder auf das Datum des letzten manuellen Imports zu ändern ist. 